### PR TITLE
Fixed bug with search on load, clear all adapters before re-populating, minor variables renaming

### DIFF
--- a/app/src/main/java/com/example/xpvehicles/activities/MainActivity.java
+++ b/app/src/main/java/com/example/xpvehicles/activities/MainActivity.java
@@ -2,16 +2,17 @@ package com.example.xpvehicles.activities;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.SearchView;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 
 import android.Manifest;
+import android.app.Activity;
 import android.app.SearchManager;
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.graphics.Rect;
 import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
@@ -21,6 +22,10 @@ import android.util.Log;
 import android.util.Patterns;
 import android.view.Menu;
 import android.view.MenuInflater;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.SearchView;
 
 import com.example.xpvehicles.R;
 import com.example.xpvehicles.fragments.ExploreFragment;

--- a/app/src/main/java/com/example/xpvehicles/activities/UserVehicleRequestsActivity.java
+++ b/app/src/main/java/com/example/xpvehicles/activities/UserVehicleRequestsActivity.java
@@ -96,6 +96,7 @@ public class UserVehicleRequestsActivity extends AppCompatActivity {
                     Log.e(TAG, "Issue with getting the requests", e);
                     return;
                 }
+                adapter.clear();
                 if (requests.size() > 0) {
                     tvNoRequests.setVisibility(View.GONE);
                     adapter.addAll(requests);

--- a/app/src/main/java/com/example/xpvehicles/adapters/RecommendedVehiclesAdapter.java
+++ b/app/src/main/java/com/example/xpvehicles/adapters/RecommendedVehiclesAdapter.java
@@ -35,12 +35,12 @@ import okhttp3.Headers;
 public class RecommendedVehiclesAdapter extends RecyclerView.Adapter<RecommendedVehiclesAdapter.ViewHolder> {
 
     public static final String TAG = "RecommendedVehiclesAdapter";
-    private List<Vehicle> mVehicles;
+    private List<Vehicle> vehicles;
     private ExploreFragment fragment;
     private MainActivity activity;
 
     public RecommendedVehiclesAdapter(ExploreFragment fragment, List<Vehicle> vehicles, MainActivity activity){
-        mVehicles = vehicles;
+        this.vehicles = vehicles;
         this.fragment = fragment;
         this.activity = activity;
     }
@@ -56,17 +56,17 @@ public class RecommendedVehiclesAdapter extends RecyclerView.Adapter<Recommended
 
     @Override
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
-        Vehicle vehicle = mVehicles.get(position);
+        Vehicle vehicle = vehicles.get(position);
         holder.setValues(vehicle);
     }
 
     @Override
     public int getItemCount() {
-        return mVehicles.size();
+        return vehicles.size();
     }
 
     public void addAll(List<Vehicle> recommendedVehicles) {
-        mVehicles.addAll(recommendedVehicles);
+        vehicles.addAll(recommendedVehicles);
         notifyDataSetChanged();
     }
 

--- a/app/src/main/java/com/example/xpvehicles/adapters/RentingVehiclesAdapter.java
+++ b/app/src/main/java/com/example/xpvehicles/adapters/RentingVehiclesAdapter.java
@@ -85,6 +85,11 @@ public class RentingVehiclesAdapter extends RecyclerView.Adapter<RentingVehicles
         notifyDataSetChanged();
     }
 
+    public void clear() {
+        vehicles.clear();
+        notifyDataSetChanged();
+    }
+
     public class ViewHolder extends RecyclerView.ViewHolder {
         private TextView tvRentingVehicleName;
         private TextView tvRentingPickUpDate;

--- a/app/src/main/java/com/example/xpvehicles/adapters/RequestsAdapter.java
+++ b/app/src/main/java/com/example/xpvehicles/adapters/RequestsAdapter.java
@@ -67,6 +67,11 @@ public class RequestsAdapter extends RecyclerView.Adapter<RequestsAdapter.ViewHo
         return vehicles.size();
     }
 
+    public void clear() {
+        vehicles.clear();
+        notifyDataSetChanged();
+    }
+
     public void addAll(List<RentVehicle> allVehicles) {
         vehicles.addAll(allVehicles);
         notifyDataSetChanged();

--- a/app/src/main/java/com/example/xpvehicles/adapters/UserVehiclesAdapter.java
+++ b/app/src/main/java/com/example/xpvehicles/adapters/UserVehiclesAdapter.java
@@ -58,6 +58,11 @@ public class UserVehiclesAdapter extends RecyclerView.Adapter<UserVehiclesAdapte
         notifyDataSetChanged();
     }
 
+    public void clear() {
+        vehicles.clear();
+        notifyDataSetChanged();
+    }
+
     public class ViewHolder extends RecyclerView.ViewHolder {
 
         private ImageView ivUserVehicle;

--- a/app/src/main/java/com/example/xpvehicles/fragments/ExploreFragment.java
+++ b/app/src/main/java/com/example/xpvehicles/fragments/ExploreFragment.java
@@ -1,8 +1,12 @@
 package com.example.xpvehicles.fragments;
 
+import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
+import android.graphics.Rect;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -11,6 +15,7 @@ import androidx.recyclerview.widget.StaggeredGridLayoutManager;
 
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
@@ -47,6 +52,7 @@ public class ExploreFragment extends Fragment {
     private FloatingActionButton fabAddVehicle;
     private SearchView searchView;
     private ImageView ivFilter;
+    private View main_layout;
 
     public ExploreFragment(MainActivity mainActivity){
         activity = mainActivity;
@@ -55,18 +61,19 @@ public class ExploreFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
+        searchView.setQuery("", false);
         searchView.clearFocus();
+        main_layout.requestFocus();
     }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup parent, Bundle savedInstanceState) {
-        // Defines the xml file for the fragment
         return inflater.inflate(R.layout.fragment_explore, parent, false);
     }
 
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
-        bind();
+        bind(view);
         queryAllVehicles();
         bindExploreAdapter(view);
         bindRecommendedAdapter(view);
@@ -75,11 +82,18 @@ public class ExploreFragment extends Fragment {
         setFilterOnClickListener();
     }
 
-    private void bind() {
-        tvNoAvailableRentVehicle = activity.findViewById(R.id.tvNoAvailableRentVehicle);
-        fabAddVehicle = activity.findViewById(R.id.fabAddVehicle);
-        searchView = activity.findViewById(R.id.searchView);
-        ivFilter = activity.findViewById(R.id.ivFilter);
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        tvNoAvailableRentVehicle.setVisibility(View.GONE);
+    }
+
+    private void bind(View view) {
+        main_layout =  view.findViewById(R.id.main_layout);
+        tvNoAvailableRentVehicle = view.findViewById(R.id.tvNoAvailableRentVehicle);
+        fabAddVehicle = view.findViewById(R.id.fabAddVehicle);
+        searchView = view.findViewById(R.id.searchView);
+        ivFilter = view.findViewById(R.id.ivFilter);
     }
 
     private void bindRecommendedAdapter(View view) {
@@ -137,7 +151,7 @@ public class ExploreFragment extends Fragment {
         parseQuery.whereNotEqualTo(QUERY_PARAMETER_OWNER, ParseUser.getCurrentUser().getObjectId());
         parseQuery.whereMatches(QUERY_PARAMETER_NAME, searchQuery, "i");
 
-        // Fetches the vehicles that start with the searchQuery or include teh searchQuery within the name
+        // Fetches the vehicles that start with the searchQuery or include the searchQuery within the name
         parseQuery.findInBackground(new FindCallback<Vehicle>() {
             @Override
             public void done(List<Vehicle> vehicles, ParseException e) {
@@ -145,13 +159,7 @@ public class ExploreFragment extends Fragment {
                     Log.e(TAG, "Issue with getting the vehicles",e);
                     return;
                 }
-                exploreAdapter.clear();
-                if (vehicles.size() > 0) {
-                    tvNoAvailableRentVehicle.setVisibility(View.GONE);
-                    exploreAdapter.addAll(vehicles);
-                } else {
-                    tvNoAvailableRentVehicle.setVisibility(View.VISIBLE);
-                }
+                addVehiclesToAdapter(vehicles);
             }
         });
     }
@@ -168,15 +176,19 @@ public class ExploreFragment extends Fragment {
                     Log.e(TAG, "Issue with getting the vehicles",e);
                     return;
                 }
-                exploreAdapter.clear();
-                if (vehicles.size() > 0) {
-                    tvNoAvailableRentVehicle.setVisibility(View.GONE);
-                    exploreAdapter.addAll(vehicles);
-                } else {
-                    tvNoAvailableRentVehicle.setVisibility(View.VISIBLE);
-                }
+                addVehiclesToAdapter(vehicles);
             }
         });
+    }
+
+    private void addVehiclesToAdapter(List<Vehicle> vehicles) {
+        exploreAdapter.clear();
+        if (vehicles.size() > 0) {
+            tvNoAvailableRentVehicle.setVisibility(View.GONE);
+            exploreAdapter.addAll(vehicles);
+        } else {
+            tvNoAvailableRentVehicle.setVisibility(View.VISIBLE);
+        }
     }
 
     private void setFilterOnClickListener() {
@@ -192,4 +204,5 @@ public class ExploreFragment extends Fragment {
     public void notifyAdapter() {
         exploreAdapter.notifyDataSetChanged();
     }
+
 }

--- a/app/src/main/java/com/example/xpvehicles/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/example/xpvehicles/fragments/ProfileFragment.java
@@ -142,6 +142,7 @@ public class ProfileFragment extends Fragment {
                     Log.e(TAG, "Issue with getting the user's vehicles",e);
                     return;
                 }
+                adapter.clear();
                 if (vehicles.size() > 0) {
                     tvUserNoVehiclesListed.setVisibility(View.GONE);
                     adapter.addAll(vehicles);

--- a/app/src/main/java/com/example/xpvehicles/fragments/RentingVehiclesFragment.java
+++ b/app/src/main/java/com/example/xpvehicles/fragments/RentingVehiclesFragment.java
@@ -76,6 +76,7 @@ public class RentingVehiclesFragment extends Fragment {
                     Log.e(TAG, "Issue with getting the vehicles",e);
                     return;
                 }
+                adapter.clear();
                 if (vehicles.size() > 0) {
                     tvUserNoRentingVehicles.setVisibility(View.GONE);
                     adapter.addAll(vehicles);

--- a/app/src/main/java/com/example/xpvehicles/fragments/SavedFragment.java
+++ b/app/src/main/java/com/example/xpvehicles/fragments/SavedFragment.java
@@ -75,6 +75,7 @@ public class SavedFragment extends Fragment {
                     Log.e(TAG, "Issue with getting the vehicles",e);
                     return;
                 }
+                adapter.clear();
                 if (vehicles.size() > 0) {
                     tvNoSavedVehicles.setVisibility(View.GONE);
                     adapter.addAll(vehicles);

--- a/app/src/main/res/layout/fragment_explore.xml
+++ b/app/src/main/res/layout/fragment_explore.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/root_layout"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/frameLayout2"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".fragments.ExploreFragment">
@@ -62,45 +62,58 @@
         </com.google.android.material.card.MaterialCardView>
     </com.google.android.material.appbar.AppBarLayout>
 
-    <HorizontalScrollView
-        android:id="@+id/horizontalScrollView"
-        android:layout_width="0dp"
-        android:layout_height="120dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/appBarLayout2">
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rvRecommendedVehicles"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent" />
-    </HorizontalScrollView>
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rvExplore"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/main_layout"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/horizontalScrollView"
-        app:layout_constraintVertical_bias="0.0"
-        tools:layout_conversion_absoluteHeight="635dp"
-        tools:layout_conversion_absoluteWidth="411dp" />
+        app:layout_constraintTop_toBottomOf="@+id/appBarLayout2"
+        android:clickable="true"
+        android:focusableInTouchMode="true">
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/fabAddVehicle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="16dp"
-        android:backgroundTint="@color/md_theme_light_primary"
-        android:contentDescription="Add a vehicle"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:srcCompat="@drawable/ic_add_24"
-        tools:layout_conversion_absoluteHeight="56dp"
-        tools:layout_conversion_absoluteWidth="56dp" />
+        <HorizontalScrollView
+            android:id="@+id/horizontalScrollView"
+            android:layout_width="0dp"
+            android:layout_height="120dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rvRecommendedVehicles"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent" />
+        </HorizontalScrollView>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rvExplore"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/horizontalScrollView"
+            tools:layout_conversion_absoluteHeight="635dp"
+            tools:layout_conversion_absoluteWidth="411dp">
+
+        </androidx.recyclerview.widget.RecyclerView>
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fabAddVehicle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:backgroundTint="@color/md_theme_light_primary"
+            android:contentDescription="Add a vehicle"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:srcCompat="@drawable/ic_add_24"
+            tools:layout_conversion_absoluteHeight="56dp"
+            tools:layout_conversion_absoluteWidth="56dp" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <TextView
         android:id="@+id/tvNoAvailableRentVehicle"


### PR DESCRIPTION
Summary Plan
- Fixed bug where the keyboard would pop up when the emulator was reloaded if the keyboard was open before the reload.
- Clear all adapters before repopulating to prevent duplicates.
- Minor variable changes/better coding practices.

Test Plan
* device loads