### PR TITLE
Display the text of previous filter constraints in the dialog fragment

### DIFF
--- a/app/src/main/java/com/example/xpvehicles/Miscellaneous/SearchAndFilter.java
+++ b/app/src/main/java/com/example/xpvehicles/Miscellaneous/SearchAndFilter.java
@@ -39,20 +39,40 @@ public class SearchAndFilter extends DialogFragment {
         this.searchQuery = searchQuery;
     }
 
+    public static String getSearchQuery() {
+        return searchQuery;
+    }
+
     public void setMaxDistance(String maxDistance) {
         this.maxDistance = maxDistance;
+    }
+
+    public static String getMaxDistance() {
+        return maxDistance;
     }
 
     public void setMinPrice(String minPrice) {
         this.minPrice = minPrice;
     }
 
+    public static String getMinPrice() {
+        return minPrice;
+    }
+
     public void setMaxPrice(String maxPrice) {
         this.maxPrice = maxPrice;
     }
 
+    public static String getMaxPrice() {
+        return maxPrice;
+    }
+
     public void setUserLocationGeoPoint(ParseGeoPoint userLocationGeoPoint) {
         this.userLocationGeoPoint = userLocationGeoPoint;
+    }
+
+    public static ParseGeoPoint getUserLocationGeoPoint() {
+        return userLocationGeoPoint;
     }
 
     public void querySearchAndFilterVehicles(FilterDialogFragment fragment, ExploreAdapter exploreAdapter, TextView tvNoAvailableRentVehicle) {
@@ -87,21 +107,6 @@ public class SearchAndFilter extends DialogFragment {
                 if (fragment != null) {
                     fragment.dismiss();
                 }
-            }
-        });
-    }
-
-    public void queryAllVehicles(ExploreAdapter exploreAdapter, TextView tvNoAvailableRentVehicle) {
-        ParseQuery<Vehicle> query = ParseQuery.getQuery(Vehicle.class);
-        query.whereNotEqualTo(KEY_OWNER, ParseUser.getCurrentUser().getObjectId());
-        query.findInBackground(new FindCallback<Vehicle>() {
-            @Override
-            public void done(List<Vehicle> vehicles, ParseException e) {
-                if (e != null) {
-                    Log.e(TAG, "Issue with getting the vehicles",e);
-                    return;
-                }
-                exploreAdapter.setVehicles(vehicles, tvNoAvailableRentVehicle);
             }
         });
     }

--- a/app/src/main/java/com/example/xpvehicles/fragments/ExploreFragment.java
+++ b/app/src/main/java/com/example/xpvehicles/fragments/ExploreFragment.java
@@ -36,7 +36,7 @@ import com.parse.ParseUser;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ExploreFragment extends SearchAndFilter implements com.example.xpvehicles.interfaces.SearchAndFilter {
+public class ExploreFragment extends SearchAndFilter {
 
     private static final String TAG = "ExploreFragment";
     private ExploreAdapter exploreAdapter;

--- a/app/src/main/java/com/example/xpvehicles/fragments/FilterDialogFragment.java
+++ b/app/src/main/java/com/example/xpvehicles/fragments/FilterDialogFragment.java
@@ -12,6 +12,9 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.example.xpvehicles.R;
 import com.example.xpvehicles.activities.MainActivity;
 import com.example.xpvehicles.adapters.ExploreAdapter;
@@ -19,7 +22,7 @@ import com.example.xpvehicles.miscellaneous.SearchAndFilter;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.parse.ParseGeoPoint;
 
-public class FilterDialogFragment extends SearchAndFilter implements com.example.xpvehicles.interfaces.SearchAndFilter {
+public class FilterDialogFragment extends SearchAndFilter {
 
     private static final String TAG = "FilterDialogFragment";
     private ExploreAdapter exploreAdapter;
@@ -31,6 +34,9 @@ public class FilterDialogFragment extends SearchAndFilter implements com.example
     private EditText etMinPrice;
     private EditText etMaxPrice;
     private Button btnFilterShowVehicles;
+    private String maxPrice;
+    private String minPrice;
+    private String maxDistance;
 
     public FilterDialogFragment(ExploreFragment exploreFragment, ExploreAdapter exploreAdapter) {
         this.exploreAdapter = exploreAdapter;
@@ -60,6 +66,7 @@ public class FilterDialogFragment extends SearchAndFilter implements com.example
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         bind(view);
+        setValues();
         setTopAppBarOnClickListener();
         setShowVehiclesOnClickListener();
         setClearAllOnCLickListener();
@@ -75,6 +82,17 @@ public class FilterDialogFragment extends SearchAndFilter implements com.example
         tvClearAll = view.findViewById(R.id.tvClearAll);
     }
 
+    private void setValues() {
+        maxDistance = getMaxDistance();
+        etMaxDistance.setText(maxDistance);
+
+        minPrice = getMinPrice();
+        etMinPrice.setText(minPrice);
+
+        maxPrice = getMaxPrice();
+        etMaxPrice.setText(maxPrice);
+    }
+
     private void setTopAppBarOnClickListener() {
         filterTopAppBar.setNavigationOnClickListener(new View.OnClickListener() {
             @Override
@@ -88,12 +106,15 @@ public class FilterDialogFragment extends SearchAndFilter implements com.example
         btnFilterShowVehicles.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                String maxPrice = String.valueOf(etMaxPrice.getText());
+                maxPrice = String.valueOf(etMaxPrice.getText());
                 setMaxPrice(maxPrice);
-                String minPrice = String.valueOf(etMinPrice.getText());
+
+                minPrice = String.valueOf(etMinPrice.getText());
                 setMinPrice(minPrice);
-                String maxDistance = String.valueOf(etMaxDistance.getText());
+
+                maxDistance = String.valueOf(etMaxDistance.getText());
                 setMaxDistance(maxDistance);
+
                 queryFilterVehicles();
             }
         });


### PR DESCRIPTION
Summary:
* When a user types a filter constraint and closes the dialog fragment, when they return, display the text values of the current constraint

Test plan:
Can type a filter constraints, close the fragment, reopen it and see the values of the current constraint